### PR TITLE
Fix chromium launching in docker

### DIFF
--- a/Integration.cs
+++ b/Integration.cs
@@ -334,6 +334,7 @@ namespace CharacterAI
                     Headless = true,
                     UserDataDir = $"{CD}{SC}puppeteer-user",
                     ExecutablePath = EXEC_PATH,
+                    Args = new []{"--no-sandbox", "--disable-setuid-sandbox"},
                     Timeout = 1_200_000 // 15 minutes
                 });
                 Success("OK");


### PR DESCRIPTION
Without these args, chromium browser cannot find a suitable sandbox to run in a docker environment 